### PR TITLE
Usage of "WebRtcRespectOsRoutingTableEnabled"

### DIFF
--- a/microsoft-365/enterprise/microsoft-365-vpn-securing-teams.md
+++ b/microsoft-365/enterprise/microsoft-365-vpn-securing-teams.md
@@ -46,7 +46,7 @@ In certain scenarios, often unrelated to Teams client configuration, media traff
 Signaling traffic is performed over HTTPS and isn't as latency sensitive as the media traffic and is marked as **Allow** in the URL/IP data and thus can safely be routed through the VPN client if desired.
 
 >[!NOTE]
->Microsoft Edge **96 and above** also supports VPN split tunneling for peer-to-peer traffic. This means customers can gain the benefit of VPN split tunneling for Teams web clients on Edge, for instance. Customers who want to set it up for websites running on Edge can achieve it by taking the additional step of enabling the Edge [WebRtcRespectOsRoutingTableEnabled](/deployedge/microsoft-edge-policies#webrtcrespectosroutingtableenabled) policy.
+>Microsoft Edge **96 and above** also supports VPN split tunneling for peer-to-peer traffic. This means customers can gain the benefit of VPN split tunneling for Teams web clients on Edge, for instance. Customers who want to set it up for websites running on Edge can achieve it by taking the additional step of setting this Edge [WebRtcRespectOsRoutingTableEnabled](/deployedge/microsoft-edge-policies#webrtcrespectosroutingtableenabled) policy to 'disabled'.
 
 ### Security
 


### PR DESCRIPTION
Hi, if I understand the description of the "WebRtcRespectOsRoutingTableEnabled"-Setting (https://docs.microsoft.com/en-us/deployedge/microsoft-edge-policies#webrtcrespectosroutingtableenabled) correctly, then the setting would need to be set to "Disabled" instead of "Enabled" for the split tunnel scenario to apply. This is not the case here. Or am i wrong?

Description:
"If you disable this policy or don't configure it, WebRTC will not consider the routing table and may make peer to peer connections over any available network.
If you enable this policy, WebRTC will prefer to make peer to peer connections using the indicated network interface for the remote address as indicated in the routing table."

Regards,
Wolfgang